### PR TITLE
Add home tab

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -8,6 +8,7 @@ import { SafeAreaProvider } from "react-native-safe-area-context";
 
 import SafeAreaScreenWrapper from "./components/SafeAreaScreenWrapper/SafeAreaScreenWrapper";
 import HelloWorldFeature from "./features/HelloWorldFeature/HelloWorldFeature";
+import HomeTab from "./features/HomeTab/HomeTab";
 
 const Tab = createBottomTabNavigator();
 
@@ -20,12 +21,7 @@ export default function App() {
           screenOptions={{ tabBarActiveTintColor: "#dc1c32", headerShown: false }}>
           <Tab.Screen
             name="Home"
-            children={() => (
-              <SafeAreaScreenWrapper>
-                {/* TODO: change this HelloWorldFeature with correct component (components which shows home tab) */}
-                <HelloWorldFeature />
-              </SafeAreaScreenWrapper>
-            )}
+            component={HomeTab}
             options={{
               tabBarLabel: "Home",
               tabBarIcon: ({ color, size }) => <AntDesign name="home" size={size} color={color} />,

--- a/App.tsx
+++ b/App.tsx
@@ -1,3 +1,6 @@
+// Why this import is necessary? See: https://reactnavigation.org/docs/stack-navigator/#installation
+import "react-native-gesture-handler";
+
 import { FontAwesome, AntDesign } from "@expo/vector-icons";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { NavigationContainer } from "@react-navigation/native";

--- a/components/SafeAreaScreenWrapper/SafeAreaScreenWrapper.tsx
+++ b/components/SafeAreaScreenWrapper/SafeAreaScreenWrapper.tsx
@@ -3,7 +3,7 @@ import { View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 interface SafeAreaScreenWrapperProps {
-  children: React.JSX.Element;
+  children: React.JSX.Element | React.JSX.Element[];
 }
 
 const SafeAreaScreenWrapper = ({ children }: SafeAreaScreenWrapperProps) => {

--- a/features/HomeTab/AdvancedFilter/AdvancedFilter.tsx
+++ b/features/HomeTab/AdvancedFilter/AdvancedFilter.tsx
@@ -1,0 +1,7 @@
+import { Text } from "react-native";
+
+const AdvancedFilter = () => {
+  return <Text>AdvancedFilter</Text>;
+};
+
+export default AdvancedFilter;

--- a/features/HomeTab/BasicFilter/BasicFilter.tsx
+++ b/features/HomeTab/BasicFilter/BasicFilter.tsx
@@ -1,0 +1,7 @@
+import { Text } from "react-native";
+
+const BasicFilter = () => {
+  return <Text>BasicFilter</Text>;
+};
+
+export default BasicFilter;

--- a/features/HomeTab/FlatOfferList/FlatOfferList.tsx
+++ b/features/HomeTab/FlatOfferList/FlatOfferList.tsx
@@ -1,0 +1,88 @@
+import { Octicons } from "@expo/vector-icons";
+import { SearchBar } from "@rneui/themed";
+import { useCallback, useState } from "react";
+import { View, Pressable, FlatList, RefreshControl } from "react-native";
+
+import FlatOfferListItem from "./FlatOfferListItem/FlatOfferListItem";
+import FlatOffer from "../../../interfaces/FlatOffer";
+
+const defaultFlatOffers: FlatOffer[] = [];
+
+for (let i = 0; i < 10; ++i) {
+  defaultFlatOffers.push({
+    id: i.toString(),
+    name: "Hackney",
+    city: "London",
+    price: Math.floor(Math.random() * (100 - 30 + 1) + 30),
+    rating: Math.random() * 5,
+    distanceFromCenter: Math.floor(Math.random() * (10 - 0 + 1) + 0),
+    imageSource:
+      "https://media.architecturaldigest.com/photos/5845c567caee54856138ed69/4:3/w_2016,h_1512,c_limit/london-hotels-05.jpg",
+  });
+}
+
+const FlatOfferList = ({ route, navigation }) => {
+  const [flatOffers, setFlatOffers] = useState<FlatOffer[]>(defaultFlatOffers);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const onRefresh = useCallback(() => {
+    setRefreshing(true);
+    setTimeout(() => {
+      setRefreshing(false);
+    }, 500);
+  }, []);
+
+  return (
+    <View
+      style={{
+        height: "100%",
+      }}>
+      <View
+        style={{
+          flexDirection: "row",
+          paddingLeft: 20,
+          paddingRight: 20,
+          paddingTop: 10,
+          paddingBottom: 10,
+          alignItems: "center",
+        }}>
+        <SearchBar
+          lightTheme
+          placeholder="Where to?"
+          onPressIn={() => {
+            navigation.navigate("BasicFilter");
+          }}
+          containerStyle={{
+            borderRadius: 100,
+            flex: 10,
+          }}
+          inputContainerStyle={{
+            backgroundColor: "transparent",
+          }}
+          showSoftInputOnFocus={false}
+        />
+        <Pressable
+          onPress={() => {
+            navigation.navigate("AdvancedFilter");
+          }}>
+          <Octicons name="filter" size={24} color="black" style={{ paddingLeft: 10 }} />
+        </Pressable>
+      </View>
+      <FlatList
+        data={flatOffers}
+        renderItem={({ item }) => (
+          <FlatOfferListItem route={route} navigation={navigation} flatOffer={item} />
+        )}
+        keyExtractor={(flatOffer: FlatOffer) => flatOffer.id}
+        contentContainerStyle={{
+          flexGrow: 1,
+          overflow: "visible",
+          minHeight: "100%",
+        }}
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+      />
+    </View>
+  );
+};
+
+export default FlatOfferList;

--- a/features/HomeTab/FlatOfferList/FlatOfferListItem/FlatOfferListItem.tsx
+++ b/features/HomeTab/FlatOfferList/FlatOfferListItem/FlatOfferListItem.tsx
@@ -1,0 +1,103 @@
+import { Octicons } from "@expo/vector-icons";
+import { Text, View, Image, Pressable, Animated } from "react-native";
+
+import FlatOffer from "../../../../interfaces/FlatOffer";
+
+interface FlatOfferListItemProps {
+  route: any;
+  navigation: any;
+  flatOffer: FlatOffer;
+}
+
+const FlatOfferListItem = ({ route, navigation, flatOffer }: FlatOfferListItemProps) => {
+  const animated = new Animated.Value(1);
+  const fadeIn = () => {
+    Animated.timing(animated, {
+      toValue: 0.4,
+      duration: 150,
+      useNativeDriver: true,
+    }).start();
+  };
+
+  const fadeOut = () => {
+    Animated.timing(animated, {
+      toValue: 1,
+      duration: 250,
+      useNativeDriver: true,
+    }).start();
+  };
+
+  return (
+    <Pressable
+      onPress={() => {
+        navigation.navigate("FlatOffer", { flatOffer });
+      }}
+      onPressIn={fadeIn}
+      onPressOut={fadeOut}>
+      <View
+        style={{
+          padding: 15,
+        }}>
+        <Animated.View style={{ opacity: animated }}>
+          <Image
+            style={{
+              height: 300,
+              borderRadius: 10,
+            }}
+            source={{
+              uri: flatOffer.imageSource,
+            }}
+          />
+
+          <View
+            style={{
+              padding: 5,
+            }}>
+            <View
+              style={{
+                flexDirection: "row",
+                justifyContent: "space-between",
+                alignItems: "center",
+              }}>
+              <Text
+                style={{
+                  fontSize: 28,
+                  fontWeight: "bold",
+                }}>
+                {flatOffer.name}, {flatOffer.city}
+              </Text>
+              <View
+                style={{
+                  flexDirection: "row",
+                  alignItems: "center",
+                }}>
+                <Octicons name="star-fill" size={24} color="black" />
+                <Text
+                  style={{
+                    padding: 5,
+                  }}>
+                  {flatOffer.rating.toFixed(2)}
+                </Text>
+              </View>
+            </View>
+
+            <Text
+              style={{
+                fontSize: 12,
+              }}>
+              {flatOffer.distanceFromCenter.toFixed(0)} km from center
+            </Text>
+            <Text
+              style={{
+                fontSize: 20,
+              }}>
+              ${flatOffer.price.toFixed(0)} night
+            </Text>
+          </View>
+        </Animated.View>
+      </View>
+    </Pressable>
+  );
+};
+
+export default FlatOfferListItem;

--- a/features/HomeTab/HomeTab.tsx
+++ b/features/HomeTab/HomeTab.tsx
@@ -1,0 +1,53 @@
+import { createStackNavigator } from "@react-navigation/stack";
+import { Text } from "react-native";
+
+import AdvancedFilter from "./AdvancedFilter/AdvancedFilter";
+import BasicFilter from "./BasicFilter/BasicFilter";
+import FlatOfferList from "./FlatOfferList/FlatOfferList";
+import SafeAreaScreenWrapper from "../../components/SafeAreaScreenWrapper/SafeAreaScreenWrapper";
+
+const HomeTab = () => {
+  const Stack = createStackNavigator();
+
+  return (
+    <Stack.Navigator initialRouteName="FlatOfferList" screenOptions={{ headerShown: false }}>
+      <Stack.Screen
+        name="FlatOfferList"
+        children={(props) => (
+          <SafeAreaScreenWrapper>
+            <FlatOfferList {...props} />
+          </SafeAreaScreenWrapper>
+        )}
+      />
+      <Stack.Screen
+        name="FlatOffer"
+        children={(props) => (
+          <SafeAreaScreenWrapper>
+            {/* TODO: change this dummy text with our flat offer component,
+             * remember to get flatOffer from props in the new component!
+             */}
+            <Text>Flat Offer...</Text>
+          </SafeAreaScreenWrapper>
+        )}
+      />
+      <Stack.Screen
+        name="BasicFilter"
+        children={() => (
+          <SafeAreaScreenWrapper>
+            <BasicFilter />
+          </SafeAreaScreenWrapper>
+        )}
+      />
+      <Stack.Screen
+        name="AdvancedFilter"
+        children={() => (
+          <SafeAreaScreenWrapper>
+            <AdvancedFilter />
+          </SafeAreaScreenWrapper>
+        )}
+      />
+    </Stack.Navigator>
+  );
+};
+
+export default HomeTab;

--- a/interfaces/FlatOffer.tsx
+++ b/interfaces/FlatOffer.tsx
@@ -1,0 +1,9 @@
+export default interface FlatOffer {
+  id: string;
+  name: string;
+  city: string;
+  price: number;
+  rating: number;
+  distanceFromCenter: number;
+  imageSource: string;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,18 @@
       "name": "mobile-app",
       "version": "1.0.0",
       "dependencies": {
+        "@react-native-masked-view/masked-view": "0.2.9",
         "@react-navigation/bottom-tabs": "^6.5.11",
         "@react-navigation/native": "^6.1.9",
+        "@react-navigation/stack": "^6.3.20",
+        "@rneui/base": "^4.0.0-rc.7",
+        "@rneui/themed": "^4.0.0-rc.8",
         "@types/react": "~18.2.14",
         "expo": "~49.0.15",
         "expo-status-bar": "~1.6.0",
         "react": "18.2.0",
         "react-native": "0.72.6",
+        "react-native-gesture-handler": "~2.12.0",
         "react-native-safe-area-context": "4.6.3",
         "react-native-screens": "~3.22.0"
       },
@@ -2013,6 +2018,17 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "dependencies": {
+        "@types/hammerjs": "^2.0.36"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -6076,6 +6092,15 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
+    "node_modules/@react-native-masked-view/masked-view": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@react-native-masked-view/masked-view/-/masked-view-0.2.9.tgz",
+      "integrity": "sha512-Hs4vKBKj+15VxHZHFtMaFWSBxXoOE5Ea8saoigWhahp8Mepssm0ezU+2pTl7DK9z8Y9s5uOl/aPb4QmBZ3R3Zw==",
+      "peerDependencies": {
+        "react": ">=16",
+        "react-native": ">=0.57"
+      }
+    },
     "node_modules/@react-native/assets-registry": {
       "version": "0.72.0",
       "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.72.0.tgz",
@@ -6224,6 +6249,66 @@
         "nanoid": "^3.1.23"
       }
     },
+    "node_modules/@react-navigation/stack": {
+      "version": "6.3.20",
+      "resolved": "https://registry.npmjs.org/@react-navigation/stack/-/stack-6.3.20.tgz",
+      "integrity": "sha512-vE6mgZzOgoa5Uy7ayT97Cj+ZIK7DK+JBYVuKUViILlWZy6IWK7HFDuqoChSbZ1ajTIfAxj/acVGg1jkbAKsToA==",
+      "dependencies": {
+        "@react-navigation/elements": "^1.3.21",
+        "color": "^4.2.3",
+        "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^6.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-gesture-handler": ">= 1.0.0",
+        "react-native-safe-area-context": ">= 3.0.0",
+        "react-native-screens": ">= 3.0.0"
+      }
+    },
+    "node_modules/@rneui/base": {
+      "version": "4.0.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@rneui/base/-/base-4.0.0-rc.7.tgz",
+      "integrity": "sha512-dffzoYek3Qp+7wJzC42QjI/Fu1HOUNxFIR88t1laDrBV5QZQB55f+Vu5zLbC80/bh1b8fYtl63HTIWpORuA3Eg==",
+      "dependencies": {
+        "@types/react-native-vector-icons": "^6.4.10",
+        "color": "^3.2.1",
+        "deepmerge": "^4.2.2",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-native-ratings": "^8.1.0",
+        "react-native-size-matters": "^0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/react-native-elements"
+      },
+      "peerDependencies": {
+        "react-native-safe-area-context": "^3.1.9 || ^4.0.0",
+        "react-native-vector-icons": ">7.0.0"
+      }
+    },
+    "node_modules/@rneui/base/node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
+    "node_modules/@rneui/themed": {
+      "version": "4.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@rneui/themed/-/themed-4.0.0-rc.8.tgz",
+      "integrity": "sha512-8L/XOrL9OK/r+/iBLvx63TbIdZOXF8SIjN9eArMYm6kRbMr8m4BitXllDN8nBhBsSPNYvL6EAgjk+i2MfY4sBA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/react-native-elements"
+      },
+      "peerDependencies": {
+        "@rneui/base": "4.0.0-rc.7"
+      }
+    },
     "node_modules/@segment/loosely-validate-event": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
@@ -6296,6 +6381,11 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true
     },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.45",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.45.tgz",
+      "integrity": "sha512-qkcUlZmX6c4J8q45taBKTL3p+LbITgyx7qhlPYOdOHZB7B31K0mXbP5YA7i7SgDeEGuI9MnumiKPEMrxg8j3KQ=="
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -6350,6 +6440,23 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-native": {
+      "version": "0.70.19",
+      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.70.19.tgz",
+      "integrity": "sha512-c6WbyCgWTBgKKMESj/8b4w+zWcZSsCforson7UdXtXMecG3MxCinYi6ihhrHVPyUrVzORsvEzK8zg32z4pK6Sg==",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-native-vector-icons": {
+      "version": "6.4.18",
+      "resolved": "https://registry.npmjs.org/@types/react-native-vector-icons/-/react-native-vector-icons-6.4.18.tgz",
+      "integrity": "sha512-YGlNWb+k5laTBHd7+uZowB9DpIK3SXUneZqAiKQaj1jnJCZM0x71GDim5JCTMi4IFkhc9m8H/Gm28T5BjyivUw==",
+      "dependencies": {
+        "@types/react": "*",
+        "@types/react-native": "^0.70"
       }
     },
     "node_modules/@types/scheduler": {
@@ -10234,6 +10341,19 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hosted-git-info": {
       "version": "3.0.8",
@@ -14532,6 +14652,34 @@
         "react": "18.2.0"
       }
     },
+    "node_modules/react-native-gesture-handler": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.12.1.tgz",
+      "integrity": "sha512-deqh36bw82CFUV9EC4tTo2PP1i9HfCOORGS3Zmv71UYhEZEHkzZv18IZNPB+2Awzj45vLIidZxGYGFxHlDSQ5A==",
+      "dependencies": {
+        "@egjs/hammerjs": "^2.0.17",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-ratings": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-ratings/-/react-native-ratings-8.1.0.tgz",
+      "integrity": "sha512-+QOJ4G3NjVkI1D+tk4EGx1dCvVfbD2nQdkrj9cXrcAoEiwmbep4z4bZbCKmWMpQ5h2dqbxABU8/eBnbDmvAc3g==",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-safe-area-context": {
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.6.3.tgz",
@@ -14552,6 +14700,80 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-size-matters": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/react-native-size-matters/-/react-native-size-matters-0.4.2.tgz",
+      "integrity": "sha512-DKE3f/sdcozd24oASgkP1iGg+YU3HoajRa5k3a4wkRzpiqREq8SGX12Y5zBgAt/8IivLQoTMYkyQu1/Giuy+zQ==",
+      "peerDependencies": {
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-vector-icons": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-10.0.3.tgz",
+      "integrity": "sha512-ZgVlV5AdQgnPHHvBEihGf2xwyziT1acpXV1U+WfCgCv3lcEeCRsmwAsBU+kUSNsU+8TcWVsX04kdI6qUaS8D7w==",
+      "peer": true,
+      "dependencies": {
+        "prop-types": "^15.7.2",
+        "yargs": "^16.1.1"
+      },
+      "bin": {
+        "fa-upgrade.sh": "bin/fa-upgrade.sh",
+        "fa5-upgrade": "bin/fa5-upgrade.sh",
+        "fa6-upgrade": "bin/fa6-upgrade.sh",
+        "generate-icon": "bin/generate-icon.js"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "peer": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "peer": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/react-native/node_modules/promise": {

--- a/package.json
+++ b/package.json
@@ -11,13 +11,18 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@react-native-masked-view/masked-view": "0.2.9",
     "@react-navigation/bottom-tabs": "^6.5.11",
     "@react-navigation/native": "^6.1.9",
+    "@react-navigation/stack": "^6.3.20",
+    "@rneui/base": "^4.0.0-rc.7",
+    "@rneui/themed": "^4.0.0-rc.8",
     "@types/react": "~18.2.14",
     "expo": "~49.0.15",
     "expo-status-bar": "~1.6.0",
     "react": "18.2.0",
     "react-native": "0.72.6",
+    "react-native-gesture-handler": "~2.12.0",
     "react-native-safe-area-context": "4.6.3",
     "react-native-screens": "~3.22.0"
   },


### PR DESCRIPTION
I added home tab. Currently basic filter and advanced filter are dummy components (showing plain text). This features will be implemented in the next pull requests.

Home tab displays list of flat offers. Every offer is press-able. After pressing one offer, you will be navigated to correct offer screen (@kemeyr is responsible for this feature).

In this short video you can see, how this home tab looks like:

https://github.com/flatly-pw/mobile-app/assets/53649257/bb45d167-0bc3-4a1b-9160-f984d7b4a939

