### PR TITLE
Move flat offer list to react native paper

### DIFF
--- a/features/HomeTab/FlatOfferList/FlatOfferList.tsx
+++ b/features/HomeTab/FlatOfferList/FlatOfferList.tsx
@@ -1,7 +1,6 @@
-import { SearchBar } from "@rneui/themed";
 import { useCallback, useState } from "react";
 import { View, FlatList, RefreshControl } from "react-native";
-import { IconButton, useTheme } from "react-native-paper";
+import { IconButton, Searchbar, useTheme } from "react-native-paper";
 
 import FlatOfferListItem from "./FlatOfferListItem/FlatOfferListItem";
 import FlatOffer from "../../../interfaces/FlatOffer";
@@ -48,18 +47,14 @@ const FlatOfferList = ({ route, navigation }) => {
           paddingBottom: 10,
           alignItems: "center",
         }}>
-        <SearchBar
-          lightTheme
+        <Searchbar
+          value=""
           placeholder="Where to?"
           onPressIn={() => {
             navigation.navigate("BasicFilter");
           }}
-          containerStyle={{
-            borderRadius: 100,
+          style={{
             flex: 10,
-          }}
-          inputContainerStyle={{
-            backgroundColor: "transparent",
           }}
           showSoftInputOnFocus={false}
         />

--- a/features/HomeTab/FlatOfferList/FlatOfferListItem/FlatOfferListItem.tsx
+++ b/features/HomeTab/FlatOfferList/FlatOfferListItem/FlatOfferListItem.tsx
@@ -1,5 +1,6 @@
 import { Octicons } from "@expo/vector-icons";
 import { Text, View, Image, Pressable, Animated } from "react-native";
+import { Surface } from "react-native-paper";
 
 import FlatOffer from "../../../../interfaces/FlatOffer";
 
@@ -38,63 +39,69 @@ const FlatOfferListItem = ({ route, navigation, flatOffer }: FlatOfferListItemPr
         style={{
           padding: 15,
         }}>
-        <Animated.View style={{ opacity: animated }}>
-          <Image
-            style={{
-              height: 300,
-              borderRadius: 10,
-            }}
-            source={{
-              uri: flatOffer.imageSource,
-            }}
-          />
+        <Surface
+          style={{
+            borderRadius: 10,
+            padding: 5,
+          }}>
+          <Animated.View style={{ opacity: animated }}>
+            <Image
+              style={{
+                height: 300,
+                borderRadius: 10,
+              }}
+              source={{
+                uri: flatOffer.imageSource,
+              }}
+            />
 
-          <View
-            style={{
-              padding: 5,
-            }}>
             <View
               style={{
-                flexDirection: "row",
-                justifyContent: "space-between",
-                alignItems: "center",
+                padding: 5,
               }}>
-              <Text
-                style={{
-                  fontSize: 28,
-                  fontWeight: "bold",
-                }}>
-                {flatOffer.name}, {flatOffer.city}
-              </Text>
               <View
                 style={{
                   flexDirection: "row",
+                  justifyContent: "space-between",
                   alignItems: "center",
                 }}>
-                <Octicons name="star-fill" size={24} color="black" />
                 <Text
                   style={{
-                    padding: 5,
+                    fontSize: 28,
+                    fontWeight: "bold",
                   }}>
-                  {flatOffer.rating.toFixed(2)}
+                  {flatOffer.name}, {flatOffer.city}
                 </Text>
+                <View
+                  style={{
+                    flexDirection: "row",
+                    alignItems: "center",
+                  }}>
+                  <Octicons name="star-fill" size={24} color="black" />
+                  <Text
+                    style={{
+                      padding: 5,
+                    }}>
+                    {flatOffer.rating.toFixed(2)}
+                  </Text>
+                </View>
               </View>
-            </View>
 
-            <Text
-              style={{
-                fontSize: 12,
-              }}>
-              {flatOffer.distanceFromCenter.toFixed(0)} km from center
-            </Text>
-            <Text
-              style={{
-                fontSize: 20,
-              }}>
-              ${flatOffer.price.toFixed(0)} night
-            </Text>
-          </View>
-        </Animated.View>
+              <Text
+                style={{
+                  fontSize: 12,
+                }}>
+                {flatOffer.distanceFromCenter.toFixed(0)} km from center
+              </Text>
+              <Text
+                style={{
+                  fontSize: 20,
+                }}>
+                ${flatOffer.price.toFixed(0)} night
+              </Text>
+            </View>
+          </Animated.View>
+        </Surface>
       </View>
     </Pressable>
   );


### PR DESCRIPTION
I moved flat offer list to `react-native-paper` components. You can see changes below (left old, right new):

<img src="https://github.com/flatly-pw/mobile-app/assets/53649257/408b0212-4f37-4e21-af6c-d54c1957b027" height="600"/>
<img src="https://github.com/flatly-pw/mobile-app/assets/53649257/2bf746bc-84b4-4ee2-8f8d-19820684b250" height="600"/>
