### PR TITLE
Add auth

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,15 +1,21 @@
 // Why this import is necessary? See: https://reactnavigation.org/docs/stack-navigator/#installation
 import "react-native-gesture-handler";
-
-import { FontAwesome, AntDesign } from "@expo/vector-icons";
+import { MaterialIcons, FontAwesome, AntDesign } from "@expo/vector-icons";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { NavigationContainer, DefaultTheme } from "@react-navigation/native";
+import * as SecureStore from "expo-secure-store";
+import * as React from "react";
 import { MD3LightTheme, adaptNavigationTheme, PaperProvider } from "react-native-paper";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 
 import SafeAreaScreenWrapper from "./components/SafeAreaScreenWrapper/SafeAreaScreenWrapper";
+import AuthContext from "./contexts/AuthContext";
+import AuthScreen from "./features/AuthScreen/AuthScreen";
 import HelloWorldFeature from "./features/HelloWorldFeature/HelloWorldFeature";
 import HomeTab from "./features/HomeTab/HomeTab";
+import SignOutTab from "./features/SignOutTab/SignOutTab";
+import SignInData from "./interfaces/SignInData";
+import SignUpData from "./interfaces/SignUpData";
 
 const Tab = createBottomTabNavigator();
 
@@ -57,6 +63,24 @@ const AppContent = () => {
           ),
         }}
       />
+      {/* TODO: REMOVE THIS SCREEN AFETER PROFILE WILL BE IMPLEMENTED! */}
+      {/* IMPORTANT NOTE: this tab screen in temporary (only for development).
+       * In the final application, signOut button will be in profile tab.
+       */}
+      <Tab.Screen
+        name="SignOut"
+        children={() => (
+          <SafeAreaScreenWrapper>
+            <SignOutTab />
+          </SafeAreaScreenWrapper>
+        )}
+        options={{
+          tabBarLabel: "DEV: SignOut",
+          tabBarIcon: ({ color, size }) => (
+            <MaterialIcons name="logout" size={size} color={color} />
+          ),
+        }}
+      />
     </Tab.Navigator>
   );
 };
@@ -64,12 +88,119 @@ const AppContent = () => {
 const { LightTheme } = adaptNavigationTheme({ reactNavigationLight: DefaultTheme });
 
 export default function App() {
+  // https://reactnavigation.org/docs/auth-flow/
+  const [state, dispatch] = React.useReducer(
+    (
+      prevState: { isLoading: boolean; isSignout: boolean; userToken: string | null },
+      action: { type: "RESTORE_TOKEN" | "SIGN_IN" | "SIGN_OUT"; token?: string | null }
+    ) => {
+      if (action.token) {
+        SecureStore.setItemAsync("userToken", action.token);
+      } else {
+        SecureStore.deleteItemAsync("userToken");
+      }
+
+      switch (action.type) {
+        case "RESTORE_TOKEN":
+          return {
+            ...prevState,
+            userToken: action.token,
+            isLoading: false,
+          };
+        case "SIGN_IN":
+          return {
+            ...prevState,
+            isSignout: false,
+            userToken: action.token,
+          };
+        case "SIGN_OUT":
+          return {
+            ...prevState,
+            isSignout: true,
+            userToken: null,
+          };
+      }
+    },
+    {
+      isLoading: true,
+      isSignout: false,
+      userToken: null,
+    }
+  );
+
+  React.useEffect(() => {
+    (async () => {
+      let userToken: string | null;
+
+      try {
+        userToken = await SecureStore.getItemAsync("userToken");
+      } catch {
+        // Token was not found in the secure store. User is not authenticated.
+        userToken = null;
+      }
+
+      dispatch({ type: "RESTORE_TOKEN", token: userToken });
+    })();
+  }, []);
+
+  const authContext = React.useMemo(
+    () => ({
+      signIn: async (data: SignInData) => {
+        const response = await fetch(process.env.EXPO_PUBLIC_API_URL + "/auth/login", {
+          method: "POST",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(data),
+        });
+
+        if (response.ok) {
+          const responseData = await response.json();
+          dispatch({ type: "SIGN_IN", token: responseData.jwttoken });
+        } else {
+          dispatch({ type: "SIGN_IN", token: null });
+        }
+      },
+      signOut: async () => {
+        await fetch(process.env.EXPO_PUBLIC_API_URL + "/auth/logout", {
+          method: "POST",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+        });
+        dispatch({ type: "SIGN_OUT" });
+      },
+      signUp: async (data: SignUpData) => {
+        const response = await fetch(process.env.EXPO_PUBLIC_API_URL + "/auth/register", {
+          method: "POST",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(data),
+        });
+
+        if (response.ok) {
+          const responseData = await response.json();
+          dispatch({ type: "SIGN_IN", token: responseData.jwttoken });
+        } else {
+          dispatch({ type: "SIGN_IN", token: null });
+        }
+      },
+    }),
+    []
+  );
+
   return (
     <PaperProvider theme={MD3LightTheme}>
       <SafeAreaProvider>
-        <NavigationContainer theme={LightTheme}>
-          <AppContent />
-        </NavigationContainer>
+        <AuthContext.Provider value={authContext}>
+          <NavigationContainer theme={LightTheme}>
+            {state.userToken === null ? <AuthScreen /> : <AppContent />}
+          </NavigationContainer>
+        </AuthContext.Provider>
       </SafeAreaProvider>
     </PaperProvider>
   );

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# flatly-mobile-app
+
+## environment variables
+
+Create file with name eg. `.env.local`:
+
+```
+EXPO_PUBLIC_API_URL=https://my-super-app.com
+```
+
+Above variables have mock values.

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+import SignInData from "../interfaces/SignInData";
+import SignUpData from "../interfaces/SignUpData";
+
+const AuthContext = React.createContext<{
+  signIn: (data: SignInData) => Promise<void>;
+  signOut: () => void;
+  signUp: (data: SignUpData) => Promise<void>;
+}>(null);
+
+export default AuthContext;

--- a/features/AuthScreen/AuthScreen.tsx
+++ b/features/AuthScreen/AuthScreen.tsx
@@ -1,0 +1,22 @@
+import { useState } from "react";
+
+import SignInScreen from "./SignInScreen/SignInScreen";
+import SignUpScreen from "./SignUpScreen/SignUpScreen";
+
+export type ScreenType = "signIn" | "signUp";
+
+const AuthScreen = () => {
+  const [screen, setScreen] = useState<ScreenType>("signIn");
+
+  const screenHandler = (newScreen: ScreenType) => {
+    setScreen(newScreen);
+  };
+
+  return screen === "signIn" ? (
+    <SignInScreen screenHandler={screenHandler} />
+  ) : (
+    <SignUpScreen screenHandler={screenHandler} />
+  );
+};
+
+export default AuthScreen;

--- a/features/AuthScreen/SignInScreen/SignInScreen.tsx
+++ b/features/AuthScreen/SignInScreen/SignInScreen.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { View } from "react-native";
+import { Button, Text, TextInput } from "react-native-paper";
+
+import SafeAreaScreenWrapper from "../../../components/SafeAreaScreenWrapper/SafeAreaScreenWrapper";
+import AuthContext from "../../../contexts/AuthContext";
+import { ScreenType } from "../AuthScreen";
+
+interface SignInScreenProps {
+  screenHandler: (newScreen: ScreenType) => void;
+}
+
+const SignInScreen = ({ screenHandler }: SignInScreenProps) => {
+  const [email, setEmail] = React.useState("");
+  const [password, setPassword] = React.useState("");
+
+  const { signIn } = React.useContext(AuthContext);
+
+  return (
+    <SafeAreaScreenWrapper>
+      <View>
+        <Text>Please login</Text>
+        <TextInput label="email" value={email} onChangeText={(newEmail) => setEmail(newEmail)} />
+        <TextInput
+          label="password"
+          value={password}
+          onChangeText={(newPassword) => setPassword(newPassword)}
+          secureTextEntry
+        />
+        <Button onPress={() => signIn({ email, password })}>Login</Button>
+        <Button onPress={() => screenHandler("signUp")}>Go to sign up page</Button>
+      </View>
+    </SafeAreaScreenWrapper>
+  );
+};
+
+export default SignInScreen;

--- a/features/AuthScreen/SignUpScreen/SignUpScreen.tsx
+++ b/features/AuthScreen/SignUpScreen/SignUpScreen.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { View } from "react-native";
+import { Button, Text, TextInput } from "react-native-paper";
+
+import SafeAreaScreenWrapper from "../../../components/SafeAreaScreenWrapper/SafeAreaScreenWrapper";
+import AuthContext from "../../../contexts/AuthContext";
+import { ScreenType } from "../AuthScreen";
+
+interface SignUpScreenProps {
+  screenHandler: (newScreen: ScreenType) => void;
+}
+const SignUpScreen = ({ screenHandler }: SignUpScreenProps) => {
+  const [name, setName] = React.useState("");
+  const [lastName, setLastName] = React.useState("");
+  const [email, setEmail] = React.useState("");
+  const [password, setPassword] = React.useState("");
+
+  const { signUp } = React.useContext(AuthContext);
+
+  return (
+    <SafeAreaScreenWrapper>
+      <View>
+        <Text>Please register</Text>
+        <TextInput label="name" value={name} onChangeText={(newName) => setName(newName)} />
+        <TextInput
+          label="lastName"
+          value={lastName}
+          onChangeText={(newLastName) => setLastName(newLastName)}
+        />
+        <TextInput label="email" value={email} onChangeText={(newEmail) => setEmail(newEmail)} />
+        <TextInput
+          label="password"
+          value={password}
+          onChangeText={(newPassword) => setPassword(newPassword)}
+          secureTextEntry
+        />
+        <Button onPress={() => signUp({ name, lastName, email, password })}>Register</Button>
+        <Button onPress={() => screenHandler("signIn")}>Go to sign in page</Button>
+      </View>
+    </SafeAreaScreenWrapper>
+  );
+};
+
+export default SignUpScreen;

--- a/features/SignOutTab/SignOutTab.tsx
+++ b/features/SignOutTab/SignOutTab.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { Button } from "react-native-paper";
+
+import SafeAreaScreenWrapper from "../../components/SafeAreaScreenWrapper/SafeAreaScreenWrapper";
+import AuthContext from "../../contexts/AuthContext";
+
+const SignOutTab = () => {
+  const { signOut } = React.useContext(AuthContext);
+
+  return (
+    <SafeAreaScreenWrapper>
+      <Button onPress={() => signOut()}>SignOut</Button>
+    </SafeAreaScreenWrapper>
+  );
+};
+
+export default SignOutTab;

--- a/interfaces/SignInData.tsx
+++ b/interfaces/SignInData.tsx
@@ -1,0 +1,4 @@
+export default interface SignInData {
+  email: string;
+  password: string;
+}

--- a/interfaces/SignUpData.tsx
+++ b/interfaces/SignUpData.tsx
@@ -1,0 +1,6 @@
+export default interface SignUpData {
+  name: string;
+  lastName: string;
+  email: string;
+  password: string;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@rneui/themed": "^4.0.0-rc.8",
         "@types/react": "~18.2.14",
         "expo": "~49.0.15",
+        "expo-secure-store": "^12.5.0",
         "expo-status-bar": "~1.6.0",
         "react": "18.2.0",
         "react-native": "0.72.6",
@@ -9604,6 +9605,14 @@
       "dependencies": {
         "compare-versions": "^3.4.0",
         "invariant": "^2.2.4"
+      }
+    },
+    "node_modules/expo-secure-store": {
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-12.5.0.tgz",
+      "integrity": "sha512-Ow2ei+SB1w4zPLxmOg2PVPf2i45Eii0T9KUaER5iRLJAMcBWN4nyGCxzESOoN3OrvxVadP0hAn6RVE1G3gdD+Q==",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-status-bar": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@rneui/themed": "^4.0.0-rc.8",
     "@types/react": "~18.2.14",
     "expo": "~49.0.15",
+    "expo-secure-store": "^12.5.0",
     "expo-status-bar": "~1.6.0",
     "react": "18.2.0",
     "react-native": "0.72.6",


### PR DESCRIPTION
In this pull request I added authentication. `SignInScreen` and `SignUpScreen` are simple views without any validation/error handling.

This pull request only add authentication with our backend server. Proper screen will be implemented in the near future. It's worth to say, that new icon on the bottom tab navigation (`SignOut`) is only temporary for development time. When profile is implemented, this button will be moved there.

IMPORTANT: To run application you have to have running backend server. You also have to set `EXPO_PUBLIC_API_URL` env variable. Read `README.md` section `#environment variables`, create proper file and fill it with data.