### PR TITLE
Add auth screens

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -92,8 +92,12 @@ export default function App() {
   const [state, dispatch] = React.useReducer(
     (
       prevState: { isLoading: boolean; isSignout: boolean; userToken: string | null },
-      action: { type: "RESTORE_TOKEN" | "SIGN_IN" | "SIGN_OUT"; token?: string | null }
-    ) => {
+      action: { type: "RESTORE_TOKEN" | "SIGN_IN" | "SIGN_OUT"; token: string | null }
+    ): {
+      userToken: string | null;
+      isLoading: boolean;
+      isSignout: boolean;
+    } => {
       if (action.token) {
         SecureStore.setItemAsync("userToken", action.token);
       } else {
@@ -158,19 +162,13 @@ export default function App() {
         if (response.ok) {
           const responseData = await response.json();
           dispatch({ type: "SIGN_IN", token: responseData.jwttoken });
-        } else {
-          dispatch({ type: "SIGN_IN", token: null });
+          return true;
         }
+        dispatch({ type: "SIGN_IN", token: null });
+        return false;
       },
-      signOut: async () => {
-        await fetch(process.env.EXPO_PUBLIC_API_URL + "/auth/logout", {
-          method: "POST",
-          headers: {
-            Accept: "application/json",
-            "Content-Type": "application/json",
-          },
-        });
-        dispatch({ type: "SIGN_OUT" });
+      signOut: () => {
+        dispatch({ type: "SIGN_OUT", token: null });
       },
       signUp: async (data: SignUpData) => {
         const response = await fetch(process.env.EXPO_PUBLIC_API_URL + "/auth/register", {
@@ -185,9 +183,10 @@ export default function App() {
         if (response.ok) {
           const responseData = await response.json();
           dispatch({ type: "SIGN_IN", token: responseData.jwttoken });
-        } else {
-          dispatch({ type: "SIGN_IN", token: null });
+          return true;
         }
+        dispatch({ type: "SIGN_IN", token: null });
+        return false;
       },
     }),
     []

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -4,9 +4,9 @@ import SignInData from "../interfaces/SignInData";
 import SignUpData from "../interfaces/SignUpData";
 
 const AuthContext = React.createContext<{
-  signIn: (data: SignInData) => Promise<void>;
+  signIn: (data: SignInData) => Promise<boolean>;
   signOut: () => void;
-  signUp: (data: SignUpData) => Promise<void>;
+  signUp: (data: SignUpData) => Promise<boolean>;
 }>(null);
 
 export default AuthContext;

--- a/features/AuthScreen/CustomTextInput.tsx
+++ b/features/AuthScreen/CustomTextInput.tsx
@@ -1,0 +1,45 @@
+import { View } from "react-native";
+import { HelperText, TextInput } from "react-native-paper";
+
+interface CustomTextInputProps {
+  label: string;
+  value: string;
+  valueHandler: (newValue: string) => void;
+  errorVisible: () => boolean;
+  errorText: () => string;
+  displayErrors: boolean;
+  secureTextEntry?: boolean;
+}
+
+const CustomTextInput = ({
+  label,
+  value,
+  valueHandler,
+  errorVisible,
+  errorText,
+  displayErrors,
+  secureTextEntry,
+}: CustomTextInputProps) => {
+  return (
+    <View
+      style={{
+        marginTop: 10,
+      }}>
+      <TextInput
+        label={label}
+        value={value}
+        onChangeText={(newPassword) => valueHandler(newPassword)}
+        secureTextEntry={secureTextEntry}
+        style={{
+          borderTopLeftRadius: 10,
+          borderTopRightRadius: 10,
+        }}
+      />
+      <HelperText type="error" visible={errorVisible() && displayErrors}>
+        {errorText()}
+      </HelperText>
+    </View>
+  );
+};
+
+export default CustomTextInput;

--- a/features/AuthScreen/SignInScreen/SignInScreen.tsx
+++ b/features/AuthScreen/SignInScreen/SignInScreen.tsx
@@ -1,34 +1,116 @@
-import React from "react";
-import { View } from "react-native";
-import { Button, Text, TextInput } from "react-native-paper";
+import { useContext, useState } from "react";
+import { Pressable, View } from "react-native";
+import { Button, HelperText, Text, useTheme } from "react-native-paper";
 
 import SafeAreaScreenWrapper from "../../../components/SafeAreaScreenWrapper/SafeAreaScreenWrapper";
 import AuthContext from "../../../contexts/AuthContext";
 import { ScreenType } from "../AuthScreen";
+import CustomTextInput from "../CustomTextInput";
 
 interface SignInScreenProps {
   screenHandler: (newScreen: ScreenType) => void;
 }
 
 const SignInScreen = ({ screenHandler }: SignInScreenProps) => {
-  const [email, setEmail] = React.useState("");
-  const [password, setPassword] = React.useState("");
+  const theme = useTheme();
 
-  const { signIn } = React.useContext(AuthContext);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [displayErrors, setDisplayErrors] = useState(false);
+  const [invalidCredentials, setInvalidCredentials] = useState(false);
+
+  const { signIn } = useContext(AuthContext);
+
+  const emailHandler = (newEmail: string) => {
+    setEmail(newEmail);
+  };
+
+  const emailErrorVisible = () => {
+    return !email.includes("@");
+  };
+
+  const emailErrorText = () => {
+    return "Invalid email address";
+  };
+
+  const passwordHandler = (newPassword: string) => {
+    setPassword(newPassword);
+  };
+
+  const passwordErrorVisible = () => {
+    return !(password.length >= 8 && password.length <= 32);
+  };
+
+  const passwordErrorText = () => {
+    return "Password should have between 8 and 32 characters";
+  };
 
   return (
     <SafeAreaScreenWrapper>
-      <View>
-        <Text>Please login</Text>
-        <TextInput label="email" value={email} onChangeText={(newEmail) => setEmail(newEmail)} />
-        <TextInput
-          label="password"
+      <View
+        style={{
+          justifyContent: "center",
+          height: "100%",
+          padding: 30,
+        }}>
+        <Text
+          variant="displaySmall"
+          style={{
+            textAlign: "center",
+            color: theme.colors.primary,
+            fontWeight: "bold",
+            marginBottom: 20,
+          }}>
+          Welcome back.
+        </Text>
+        <CustomTextInput
+          label="Email"
+          value={email}
+          valueHandler={emailHandler}
+          errorVisible={emailErrorVisible}
+          errorText={emailErrorText}
+          displayErrors={displayErrors}
+        />
+        <CustomTextInput
+          label="Password"
           value={password}
-          onChangeText={(newPassword) => setPassword(newPassword)}
+          valueHandler={passwordHandler}
+          errorVisible={passwordErrorVisible}
+          errorText={passwordErrorText}
+          displayErrors={displayErrors}
           secureTextEntry
         />
-        <Button onPress={() => signIn({ email, password })}>Login</Button>
-        <Button onPress={() => screenHandler("signUp")}>Go to sign up page</Button>
+        <Button
+          mode="contained"
+          style={{
+            borderRadius: 5,
+            marginTop: 20,
+          }}
+          onPress={async () => {
+            setDisplayErrors(true);
+            if (!emailErrorVisible() && !passwordErrorVisible()) {
+              const response = await signIn({ email, password });
+              if (!response.valueOf()) {
+                setInvalidCredentials(true);
+              }
+            }
+          }}>
+          LOGIN
+        </Button>
+        <HelperText type="error" visible={invalidCredentials}>
+          Invalid email or password.
+        </HelperText>
+        <View
+          style={{
+            flexDirection: "row",
+            justifyContent: "center",
+            padding: 10,
+          }}>
+          <Text>Don't have an account? </Text>
+          <Pressable onPress={() => screenHandler("signUp")}>
+            <Text style={{ color: theme.colors.primary, fontWeight: "bold" }}>Sign up</Text>
+          </Pressable>
+        </View>
       </View>
     </SafeAreaScreenWrapper>
   );

--- a/features/AuthScreen/SignUpScreen/SignUpScreen.tsx
+++ b/features/AuthScreen/SignUpScreen/SignUpScreen.tsx
@@ -31,7 +31,7 @@ const SignUpScreen = ({ screenHandler }: SignUpScreenProps) => {
   };
 
   const nameErrorText = () => {
-    return "Name should have at least one character";
+    return "Name cannot be empty";
   };
 
   const lastNameHandler = (newLastName: string) => {
@@ -43,7 +43,7 @@ const SignUpScreen = ({ screenHandler }: SignUpScreenProps) => {
   };
 
   const lastNameErrorText = () => {
-    return "Last Name should have at least one character";
+    return "Last Name cannot be empty";
   };
 
   const emailHandler = (newEmail: string) => {

--- a/features/AuthScreen/SignUpScreen/SignUpScreen.tsx
+++ b/features/AuthScreen/SignUpScreen/SignUpScreen.tsx
@@ -1,41 +1,157 @@
-import React from "react";
-import { View } from "react-native";
-import { Button, Text, TextInput } from "react-native-paper";
+import { useContext, useState } from "react";
+import { Pressable, View } from "react-native";
+import { Button, HelperText, Text, useTheme } from "react-native-paper";
 
 import SafeAreaScreenWrapper from "../../../components/SafeAreaScreenWrapper/SafeAreaScreenWrapper";
 import AuthContext from "../../../contexts/AuthContext";
 import { ScreenType } from "../AuthScreen";
+import CustomTextInput from "../CustomTextInput";
 
 interface SignUpScreenProps {
   screenHandler: (newScreen: ScreenType) => void;
 }
 const SignUpScreen = ({ screenHandler }: SignUpScreenProps) => {
-  const [name, setName] = React.useState("");
-  const [lastName, setLastName] = React.useState("");
-  const [email, setEmail] = React.useState("");
-  const [password, setPassword] = React.useState("");
+  const theme = useTheme();
 
-  const { signUp } = React.useContext(AuthContext);
+  const [name, setName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [displayErrors, setDisplayErrors] = useState(false);
+  const [invalidCredentials, setInvalidCredentials] = useState(false);
+
+  const { signUp } = useContext(AuthContext);
+
+  const nameHandler = (newName: string) => {
+    setName(newName);
+  };
+
+  const nameErrorVisible = () => {
+    return !(name.length > 0);
+  };
+
+  const nameErrorText = () => {
+    return "Name should have at least one character";
+  };
+
+  const lastNameHandler = (newLastName: string) => {
+    setLastName(newLastName);
+  };
+
+  const lastNameErrorVisible = () => {
+    return !(lastName.length > 0);
+  };
+
+  const lastNameErrorText = () => {
+    return "Last Name should have at least one character";
+  };
+
+  const emailHandler = (newEmail: string) => {
+    setEmail(newEmail);
+  };
+
+  const emailErrorVisible = () => {
+    return !email.includes("@");
+  };
+
+  const emailErrorText = () => {
+    return "Invalid email address";
+  };
+
+  const passwordHandler = (newPassword: string) => {
+    setPassword(newPassword);
+  };
+
+  const passwordErrorVisible = () => {
+    return !(password.length >= 8 && password.length <= 32);
+  };
+
+  const passwordErrorText = () => {
+    return "Password should have between 8 and 32 characters";
+  };
 
   return (
     <SafeAreaScreenWrapper>
-      <View>
-        <Text>Please register</Text>
-        <TextInput label="name" value={name} onChangeText={(newName) => setName(newName)} />
-        <TextInput
-          label="lastName"
-          value={lastName}
-          onChangeText={(newLastName) => setLastName(newLastName)}
+      <View
+        style={{
+          justifyContent: "center",
+          height: "100%",
+          padding: 30,
+        }}>
+        <Text
+          variant="displaySmall"
+          style={{
+            textAlign: "center",
+            color: theme.colors.primary,
+            fontWeight: "bold",
+            marginBottom: 20,
+          }}>
+          Create Account
+        </Text>
+        <CustomTextInput
+          label="Name"
+          value={name}
+          valueHandler={nameHandler}
+          errorVisible={nameErrorVisible}
+          errorText={nameErrorText}
+          displayErrors={displayErrors}
         />
-        <TextInput label="email" value={email} onChangeText={(newEmail) => setEmail(newEmail)} />
-        <TextInput
-          label="password"
+        <CustomTextInput
+          label="Last Name"
+          value={lastName}
+          valueHandler={lastNameHandler}
+          errorVisible={lastNameErrorVisible}
+          errorText={lastNameErrorText}
+          displayErrors={displayErrors}
+        />
+        <CustomTextInput
+          label="Email"
+          value={email}
+          valueHandler={emailHandler}
+          errorVisible={emailErrorVisible}
+          errorText={emailErrorText}
+          displayErrors={displayErrors}
+        />
+        <CustomTextInput
+          label="Password"
           value={password}
-          onChangeText={(newPassword) => setPassword(newPassword)}
+          valueHandler={passwordHandler}
+          errorVisible={passwordErrorVisible}
+          errorText={passwordErrorText}
+          displayErrors={displayErrors}
           secureTextEntry
         />
-        <Button onPress={() => signUp({ name, lastName, email, password })}>Register</Button>
-        <Button onPress={() => screenHandler("signIn")}>Go to sign in page</Button>
+        <Button
+          mode="contained"
+          style={{
+            borderRadius: 5,
+            marginTop: 20,
+          }}
+          onPress={async () => {
+            setDisplayErrors(true);
+            if (!emailErrorVisible() && !passwordErrorVisible()) {
+              const response = await signUp({ name, lastName, email, password });
+              if (!response.valueOf()) {
+                setInvalidCredentials(true);
+              }
+            }
+          }}>
+          SIGN UP
+        </Button>
+        <HelperText type="error" visible={invalidCredentials}>
+          Email address already in use.
+        </HelperText>
+        <View
+          style={{
+            flexDirection: "row",
+            justifyContent: "center",
+            padding: 10,
+          }}>
+          <Text>Already have an account? </Text>
+          <Pressable onPress={() => screenHandler("signIn")}>
+            <Text style={{ color: theme.colors.primary, fontWeight: "bold" }}>Login</Text>
+          </Pressable>
+        </View>
       </View>
     </SafeAreaScreenWrapper>
   );


### PR DESCRIPTION
Add `signIn` and `signOut` screens with error handling. You can see in the video below:

https://github.com/flatly-pw/mobile-app/assets/53649257/3c7ddff1-5713-48ad-af26-d2f2547ffb4f
